### PR TITLE
Make 'WHERE' optional

### DIFF
--- a/src/main/java/net/ninjacat/omg/conditions/AlwaysTrueCondition.java
+++ b/src/main/java/net/ninjacat/omg/conditions/AlwaysTrueCondition.java
@@ -1,0 +1,22 @@
+package net.ninjacat.omg.conditions;
+
+import net.ninjacat.omg.utils.Strings;
+
+public class AlwaysTrueCondition implements Condition {
+    public static final AlwaysTrueCondition INSTANCE = new AlwaysTrueCondition();
+
+    @Override
+    public String repr(final int level) {
+        return Strings.indent("", level * 2) + "true";
+    }
+
+    @Override
+    public ConditionMethod getMethod() {
+        return ConditionMethod.EQ;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof AlwaysTrueCondition;
+    }
+}

--- a/src/main/java/net/ninjacat/omg/omql/QueryCompiler.java
+++ b/src/main/java/net/ninjacat/omg/omql/QueryCompiler.java
@@ -1,5 +1,6 @@
 package net.ninjacat.omg.omql;
 
+import net.ninjacat.omg.conditions.AlwaysTrueCondition;
 import net.ninjacat.omg.conditions.Condition;
 import net.ninjacat.omg.conditions.Conditions;
 import net.ninjacat.omg.errors.OmqlParsingException;
@@ -67,6 +68,9 @@ public final class QueryCompiler {
     public Condition getCondition() {
         final Conditions.LogicalConditionBuilder builder = Conditions.matcher();
 
+        if (where == null) {
+            return AlwaysTrueCondition.INSTANCE;
+        }
         final OmqlParser.ExprContext expr = where.expr();
         processExpression(expr, builder);
 

--- a/src/main/java/net/ninjacat/omg/patterns/AlwaysMatchingPattern.java
+++ b/src/main/java/net/ninjacat/omg/patterns/AlwaysMatchingPattern.java
@@ -1,0 +1,19 @@
+package net.ninjacat.omg.patterns;
+
+public final class AlwaysMatchingPattern<T> implements Pattern<T> {
+
+    static final AlwaysMatchingPattern INSTANCE = new AlwaysMatchingPattern();
+
+    private AlwaysMatchingPattern() {
+    }
+
+    @Override
+    public boolean matches(final T instance) {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "true";
+    }
+}

--- a/src/main/java/net/ninjacat/omg/patterns/Patterns.java
+++ b/src/main/java/net/ninjacat/omg/patterns/Patterns.java
@@ -20,6 +20,7 @@ public final class Patterns {
     @SuppressWarnings("unchecked")
     private static <T> Pattern<T> processCondition(final Condition condition, final PropertyPatternCompiler<T> propBuilder) {
         return Match(condition).of(
+                Case($(instanceOf(AlwaysTrueCondition.class)), trueCondition -> processAlwaysTrueCondition()),
                 Case($(instanceOf(AndCondition.class)), andCondition -> processAndCondition(andCondition, propBuilder)),
                 Case($(instanceOf(OrCondition.class)), orCondition -> processOrCondition(orCondition, propBuilder)),
                 Case($(instanceOf(NotCondition.class)), notCondition -> processNotCondition(notCondition, propBuilder)),
@@ -32,6 +33,10 @@ public final class Patterns {
 
     private static <T, P> PropertyPattern<T> processPropertyCondition(final PropertyCondition<P> condition, final PropertyPatternCompiler<T> propBuilder) {
         return propBuilder.build(condition);
+    }
+
+    private static <T> Pattern<T> processAlwaysTrueCondition() {
+        return AlwaysMatchingPattern.INSTANCE;
     }
 
     private static <T> Pattern<T> processAndCondition(final AndCondition condition, final PropertyPatternCompiler<T> propBuilder) {

--- a/src/test/java/net/ninjacat/omg/omql/OmqlIntegrationTest.java
+++ b/src/test/java/net/ninjacat/omg/omql/OmqlIntegrationTest.java
@@ -34,6 +34,27 @@ public class OmqlIntegrationTest {
         assertThat(result, hasItems(new Data(1, 5.5, "test 1", (short) 30, E.E1)));
     }
 
+    @Test
+    public void shouldHandleNoWhere() {
+        final QueryCompiler queryCompiler = QueryCompiler.of("select name, age from Data", Data.class);
+        final Condition condition = queryCompiler.getCondition();
+
+        final Pattern pattern = Patterns.compile(
+                condition,
+                PatternCompiler.forClass(Data.class));
+
+        final List<Data> test = io.vavr.collection.List.of(
+                new Data(1, 5.5, "test 1", (short) 30, E.E1),
+                new Data(2, 6.5, "test 2", (short) 20, E.E2)
+        ).asJava();
+
+        final List<Data> result = test.stream().filter(pattern::matches).collect(Collectors.toList());
+
+        assertThat(result, hasItems(
+                new Data(1, 5.5, "test 1", (short) 30, E.E1),
+                new Data(2, 6.5, "test 2", (short) 20, E.E2)));
+    }
+
     public enum E {
         E1,
         E2

--- a/src/test/java/net/ninjacat/omg/omql/QueryCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/omql/QueryCompilerTest.java
@@ -1,5 +1,6 @@
 package net.ninjacat.omg.omql;
 
+import net.ninjacat.omg.conditions.AlwaysTrueCondition;
 import net.ninjacat.omg.conditions.Condition;
 import net.ninjacat.omg.conditions.Conditions;
 import net.ninjacat.omg.errors.OmqlParsingException;
@@ -186,6 +187,17 @@ public class QueryCompilerTest {
 
         assertThat(condition, is(expected));
     }
+
+    @Test
+    public void shouldParseQueryWithoutWhere() {
+        final QueryCompiler queryCompiler = QueryCompiler.of("select name, age from Person", SOURCES);
+        final Condition condition = queryCompiler.getCondition();
+
+        final Condition expected = AlwaysTrueCondition.INSTANCE;
+
+        assertThat(condition, is(expected));
+    }
+
 
     @Test(expected = OmqlParsingException.class)
     public void shouldFailToParseQuery() {


### PR DESCRIPTION
Added "always true" condition which is returned when there is no "WHERE"
in OMQL query.
Added "always matching" pattern which is used when there is
"always true" condition.

Added unit tests to test both.