### PR TITLE
Replace List in conditions and compiler with Collection.

### DIFF
--- a/src/main/java/net/ninjacat/omg/bytecode/primitive/InPropertyPattern.java
+++ b/src/main/java/net/ninjacat/omg/bytecode/primitive/InPropertyPattern.java
@@ -22,29 +22,29 @@ import net.ninjacat.omg.bytecode.BasePropertyPattern;
 import net.ninjacat.omg.bytecode.Property;
 import net.ninjacat.omg.errors.TypeConversionException;
 
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 public abstract class InPropertyPattern<T, E> extends BasePropertyPattern<T> {
-    private final List<E> matchingValue;
+    private final Collection<E> matchingValue;
 
     protected InPropertyPattern(final Property property, final T matchingValue) {
         super(property);
         this.matchingValue = getMatchingValueConverted(matchingValue);
     }
 
-    private List<E> getMatchingValueConverted(final T mv) {
+    private Collection<E> getMatchingValueConverted(final T mv) {
         if (mv == null) {
-            return Collections.emptyList();
-        } else if (mv instanceof List) {
+            return Collections.emptySet();
+        } else if (mv instanceof Collection) {
             //noinspection unchecked
-            return Collections.unmodifiableList((List<E>) mv);
+            return Collections.unmodifiableCollection((Collection<E>) mv);
         } else {
-            throw new TypeConversionException(mv.getClass(), mv, List.class);
+            throw new TypeConversionException(mv.getClass(), mv, Collection.class);
         }
     }
 
-    public List<E> getMatchingValue() {
+    public Collection<E> getMatchingValue() {
         return matchingValue;
     }
 
@@ -56,7 +56,7 @@ public abstract class InPropertyPattern<T, E> extends BasePropertyPattern<T> {
      * @param propertyValue value of the property
      * @return true if list contains property value
      */
-    public boolean isInList(final List<E> matchingValue, final E propertyValue) {
+    public boolean isInCollection(final Collection<E> matchingValue, final E propertyValue) {
         return matchingValue.stream().anyMatch(item -> item.equals(propertyValue));
     }
 }

--- a/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveDoubleInStrategy.java
+++ b/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveDoubleInStrategy.java
@@ -67,8 +67,8 @@ public class PrimitiveDoubleInStrategy extends PrimitiveInStrategy {
         mv.visitMethodInsn(
                 INVOKEVIRTUAL,
                 Type.getInternalName(getParentPropertyPatternClass()),
-                "isInList",
-                IS_IN_LIST_DESC,
+                METHOD,
+                IS_IN_COLLECTION_DESC,
                 false
         );
     }

--- a/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveFloatInStrategy.java
+++ b/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveFloatInStrategy.java
@@ -67,8 +67,8 @@ public class PrimitiveFloatInStrategy extends PrimitiveInStrategy {
         mv.visitMethodInsn(
                 INVOKEVIRTUAL,
                 Type.getInternalName(getParentPropertyPatternClass()),
-                "isInList",
-                IS_IN_LIST_DESC,
+                METHOD,
+                IS_IN_COLLECTION_DESC,
                 false
         );
     }

--- a/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveInStrategy.java
+++ b/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveInStrategy.java
@@ -25,14 +25,15 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
-import java.util.List;
+import java.util.Collection;
 
 import static org.objectweb.asm.Opcodes.*;
 
 public abstract class PrimitiveInStrategy implements PatternCompilerStrategy {
-    protected static final String IS_IN_LIST_DESC = Type.getMethodDescriptor(
+    protected static final String METHOD = "isInCollection";
+    static final String IS_IN_COLLECTION_DESC = Type.getMethodDescriptor(
             Type.getType(boolean.class),
-            Type.getType(List.class),
+            Type.getType(Collection.class),
             Type.getType(Object.class));
 
 
@@ -52,8 +53,8 @@ public abstract class PrimitiveInStrategy implements PatternCompilerStrategy {
         mv.visitMethodInsn(
                 INVOKEVIRTUAL,
                 Type.getInternalName(getParentPropertyPatternClass()),
-                "isInList",
-                IS_IN_LIST_DESC,
+                METHOD,
+                IS_IN_COLLECTION_DESC,
                 false
         );
     }
@@ -90,7 +91,7 @@ public abstract class PrimitiveInStrategy implements PatternCompilerStrategy {
 
     @Override
     public String getMatchingValueDescriptor() {
-        return "()Ljava/util/List;";
+        return Type.getMethodDescriptor(Type.getType(Collection.class));
     }
 
 }

--- a/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveLongInStrategy.java
+++ b/src/main/java/net/ninjacat/omg/bytecode/primitive/PrimitiveLongInStrategy.java
@@ -67,8 +67,8 @@ public class PrimitiveLongInStrategy extends PrimitiveInStrategy {
         mv.visitMethodInsn(
                 INVOKEVIRTUAL,
                 Type.getInternalName(getParentPropertyPatternClass()),
-                "isInList",
-                IS_IN_LIST_DESC,
+                METHOD,
+                IS_IN_COLLECTION_DESC,
                 false
         );
     }

--- a/src/main/java/net/ninjacat/omg/bytecode/reference/InPropertyPattern.java
+++ b/src/main/java/net/ninjacat/omg/bytecode/reference/InPropertyPattern.java
@@ -22,33 +22,34 @@ import net.ninjacat.omg.bytecode.BasePropertyPattern;
 import net.ninjacat.omg.bytecode.Property;
 import net.ninjacat.omg.errors.TypeConversionException;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 public abstract class InPropertyPattern<T, E> extends BasePropertyPattern<T> {
-    private final List<E> matchingValue;
+    private final Collection<E> matchingValue;
 
     protected InPropertyPattern(final Property property, final T matchingValue) {
         super(property);
         this.matchingValue = getMatchingValueConverted(matchingValue);
     }
 
-    private List<E> getMatchingValueConverted(final T mv) {
+    private Collection<E> getMatchingValueConverted(final T mv) {
         if (mv == null) {
-            return Collections.emptyList();
-        } else if (mv instanceof List) {
+            return Collections.emptySet();
+        } else if (mv instanceof Collection) {
             //noinspection unchecked
-            return Collections.unmodifiableList((List<E>)mv);
+            return Collections.unmodifiableCollection((Collection<E>) mv);
         } else {
             throw new TypeConversionException(mv.getClass(), mv, List.class);
         }
     }
 
-    public List<E> getMatchingValue() {
+    public Collection<E> getMatchingValue() {
         return matchingValue;
     }
 
-    public boolean isInList(final E propertyValue, final List<E> matchingValue) {
+    public boolean isInCollection(final E propertyValue, final Collection<E> matchingValue) {
         return matchingValue.stream().anyMatch(item -> item.equals(propertyValue));
     }
 }

--- a/src/main/java/net/ninjacat/omg/bytecode/reference/ReferenceInStrategy.java
+++ b/src/main/java/net/ninjacat/omg/bytecode/reference/ReferenceInStrategy.java
@@ -23,16 +23,16 @@ import net.ninjacat.omg.patterns.PropertyPattern;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
-import java.util.List;
+import java.util.Collection;
 
 import static org.objectweb.asm.Opcodes.*;
 
 
 public class ReferenceInStrategy implements PatternCompilerStrategy {
-    private static final String IS_IN_LIST_DESC = Type.getMethodDescriptor(
+    private static final String IS_IN_COLLECTION_DESC = Type.getMethodDescriptor(
             Type.getType(boolean.class),
             Type.getType(Object.class),
-            Type.getType(List.class));
+            Type.getType(Collection.class));
 
     @Override
     public Class<? extends PropertyPattern> getParentPropertyPatternClass() {
@@ -44,8 +44,8 @@ public class ReferenceInStrategy implements PatternCompilerStrategy {
         mv.visitMethodInsn(
                 INVOKEVIRTUAL,
                 Type.getInternalName(getParentPropertyPatternClass()),
-                "isInList",
-                IS_IN_LIST_DESC,
+                "isInCollection",
+                IS_IN_COLLECTION_DESC,
                 false
         );
     }
@@ -72,7 +72,7 @@ public class ReferenceInStrategy implements PatternCompilerStrategy {
 
     @Override
     public String getMatchingValueDescriptor() {
-        return "()Ljava/util/List;";
+        return Type.getMethodDescriptor(Type.getType(Collection.class));
     }
 
 }

--- a/src/main/java/net/ninjacat/omg/conditions/Conditions.java
+++ b/src/main/java/net/ninjacat/omg/conditions/Conditions.java
@@ -21,6 +21,7 @@ package net.ninjacat.omg.conditions;
 import net.ninjacat.omg.errors.ConditionException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -114,7 +115,7 @@ public final class Conditions {
             return parentBuilder;
         }
 
-        public <T> LogicalConditionBuilder in(final List<T> value) {
+        public <T> LogicalConditionBuilder in(final Collection<T> value) {
             parentBuilder.addCondition(() -> new InCondition<>(propertyName, value));
             return parentBuilder;
         }

--- a/src/main/java/net/ninjacat/omg/conditions/InCondition.java
+++ b/src/main/java/net/ninjacat/omg/conditions/InCondition.java
@@ -18,11 +18,11 @@
 
 package net.ninjacat.omg.conditions;
 
-import java.util.List;
+import java.util.Collection;
 
-public class InCondition<T> extends ComparisonCondition<List<T>> {
+public class InCondition<T> extends ComparisonCondition<Collection<T>> {
 
-    public InCondition(final String property, final List<T> value) {
+    public InCondition(final String property, final Collection<T> value) {
         super(property, value);
     }
 

--- a/src/main/java/net/ninjacat/omg/omql/InProducer.java
+++ b/src/main/java/net/ninjacat/omg/omql/InProducer.java
@@ -23,7 +23,7 @@ import net.ninjacat.omg.errors.OmqlParsingException;
 import net.ninjacat.omg.omql.parser.OmqlParser;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -36,18 +36,18 @@ public class InProducer implements OmqlConditionProducer<OmqlParser.InExprContex
                        final String property,
                        final QueryContext context,
                        final OmqlParser.InExprContext value) {
-        final List<Object> values = value.list().literal_value().stream()
+        final Set<Object> values = value.list().literal_value().stream()
                 .map(it -> context.validator().validate(property, it.getText()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
 
         if (values.isEmpty()) {
             builder.property(property).in(Collections.emptyList());
         } else {
-            final Class<?> firstClass = values.get(0).getClass();
+            final Class<?> firstClass = values.iterator().next().getClass();
             if (!values.stream().allMatch(it -> firstClass.isAssignableFrom(it.getClass()))) {
                 throw new OmqlParsingException("All elements of IN operation should be of same type");
             }
-            final List<Object> items = values.stream().map(firstClass::cast).collect(Collectors.toList());
+            final Set<Object> items = values.stream().map(firstClass::cast).collect(Collectors.toSet());
             builder.property(property).in(items);
         }
     }

--- a/src/main/java/net/ninjacat/omg/reflect/BaseInPattern.java
+++ b/src/main/java/net/ninjacat/omg/reflect/BaseInPattern.java
@@ -21,15 +21,15 @@ package net.ninjacat.omg.reflect;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import net.ninjacat.omg.utils.TypeUtils;
 
-import java.util.List;
+import java.util.Collection;
 
 public abstract class BaseInPattern<T, V> implements PropertyPattern<T> {
 
     private final Property<T> property;
-    private final List<V> matchingValue;
+    private final Collection<V> matchingValue;
 
     @SuppressWarnings("unchecked")
-    BaseInPattern(final Property<T> property, final List<V> matchingValue) {
+    BaseInPattern(final Property<T> property, final Collection<V> matchingValue) {
         this.property = property;
         this.matchingValue = io.vavr.collection.List.ofAll(matchingValue).map(it -> (V) TypeUtils.convertToBasicType(it)).toJavaList();
     }
@@ -38,7 +38,7 @@ public abstract class BaseInPattern<T, V> implements PropertyPattern<T> {
         return property;
     }
 
-    public List<V> getMatchingValue() {
+    public Collection<V> getMatchingValue() {
         return matchingValue;
     }
 

--- a/src/main/java/net/ninjacat/omg/reflect/DoubleInPattern.java
+++ b/src/main/java/net/ninjacat/omg/reflect/DoubleInPattern.java
@@ -20,12 +20,12 @@ package net.ninjacat.omg.reflect;
 
 import net.jcip.annotations.Immutable;
 
-import java.util.List;
+import java.util.Collection;
 
 @Immutable
 public class DoubleInPattern<T> extends BaseInPattern<T, Double> {
 
-    DoubleInPattern(final Property<T> property, final List<Double> matchingValue) {
+    DoubleInPattern(final Property<T> property, final Collection<Double> matchingValue) {
         super(property, matchingValue);
     }
 

--- a/src/main/java/net/ninjacat/omg/reflect/EnumInPattern.java
+++ b/src/main/java/net/ninjacat/omg/reflect/EnumInPattern.java
@@ -20,12 +20,12 @@ package net.ninjacat.omg.reflect;
 
 import net.jcip.annotations.Immutable;
 
-import java.util.List;
+import java.util.Collection;
 
 @Immutable
 public class EnumInPattern<T> extends BaseInPattern<T, Enum> {
 
-    EnumInPattern(final Property<T> property, final List<Enum> matchingValue) {
+    EnumInPattern(final Property<T> property, final Collection<Enum> matchingValue) {
         super(property, matchingValue);
     }
 

--- a/src/main/java/net/ninjacat/omg/reflect/LongInPattern.java
+++ b/src/main/java/net/ninjacat/omg/reflect/LongInPattern.java
@@ -20,12 +20,12 @@ package net.ninjacat.omg.reflect;
 
 import net.jcip.annotations.Immutable;
 
-import java.util.List;
+import java.util.Collection;
 
 @Immutable
 public class LongInPattern<T> extends BaseInPattern<T, Long> {
 
-    LongInPattern(final Property<T> property, final List<Long> matchingValue) {
+    LongInPattern(final Property<T> property, final Collection<Long> matchingValue) {
         super(property, matchingValue);
     }
 

--- a/src/main/java/net/ninjacat/omg/reflect/ReflectPatternCompiler.java
+++ b/src/main/java/net/ninjacat/omg/reflect/ReflectPatternCompiler.java
@@ -32,7 +32,7 @@ import net.ninjacat.omg.patterns.Patterns;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import net.ninjacat.omg.patterns.PropertyPatternCompiler;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.function.Predicate;
 
 import static io.vavr.API.*;
@@ -74,10 +74,10 @@ public final class ReflectPatternCompiler<T> implements PropertyPatternCompiler<
         @SuppressWarnings("CastToConcreteClass") final InCondition<P> condition = (InCondition<P>) propCondition;
         final Property<T> property = createProperty(condition.getProperty());
         return Match(property.getWidenedType()).of(
-                Case($(is(Long.class)), l -> new LongInPattern<>(property, (List<Long>) condition.getValue())),
-                Case($(is(Double.class)), d -> new DoubleInPattern<>(property, (List<Double>) condition.getValue())),
-                Case($(is(String.class)), s -> new StringInPattern<>(property, (List<String>) condition.getValue())),
-                Case($(ReflectPatternCompiler::isEnum), e -> new EnumInPattern<>(property, (List<Enum>) condition.getValue())),
+                Case($(is(Long.class)), l -> new LongInPattern<>(property, (Collection<Long>) condition.getValue())),
+                Case($(is(Double.class)), d -> new DoubleInPattern<>(property, (Collection<Double>) condition.getValue())),
+                Case($(is(String.class)), s -> new StringInPattern<>(property, (Collection<String>) condition.getValue())),
+                Case($(ReflectPatternCompiler::isEnum), e -> new EnumInPattern<>(property, (Collection<Enum>) condition.getValue())),
                 Case($(), () -> {
                     throw new CompilerException("Object fields are not supported for IN condition '%s", propCondition);
                 })

--- a/src/main/java/net/ninjacat/omg/reflect/StringInPattern.java
+++ b/src/main/java/net/ninjacat/omg/reflect/StringInPattern.java
@@ -20,12 +20,12 @@ package net.ninjacat.omg.reflect;
 
 import net.jcip.annotations.Immutable;
 
-import java.util.List;
+import java.util.Collection;
 
 @Immutable
 public class StringInPattern<T> extends BaseInPattern<T, String> {
 
-    StringInPattern(final Property<T> property, final List<String> matchingValue) {
+    StringInPattern(final Property<T> property, final Collection<String> matchingValue) {
         super(property, matchingValue);
     }
 

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/BooleanCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/BooleanCompilerTest.java
@@ -9,6 +9,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -50,7 +52,7 @@ public class BooleanCompilerTest {
 
     @Test(expected = CompilerException.class)
     public void shouldFailInPattern() {
-        final PropertyCondition<java.util.List<Boolean>> condition =
+        final PropertyCondition<Collection<Boolean>> condition =
                 new InCondition<>("boolField", List.of(true, false).asJava());
 
         AsmPatternCompiler.forClass(BooleanTest.class).build(condition);

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/ByteCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/ByteCompilerTest.java
@@ -9,6 +9,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -57,7 +59,7 @@ public class ByteCompilerTest {
 
     @Test
     public void shouldMatchInPattern() {
-        final PropertyCondition<java.util.List<Byte>> condition =
+        final PropertyCondition<Collection<Byte>> condition =
                 new InCondition<>("byteField", List.of((byte) 42, (byte) 84).asJava());
 
         final PropertyPattern<ByteTest> pattern = AsmPatternCompiler.forClass(ByteTest.class).build(condition);

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/CharCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/CharCompilerTest.java
@@ -1,6 +1,6 @@
 package net.ninjacat.omg.bytecode.primitive;
 
-import io.vavr.collection.List;
+import io.vavr.collection.HashSet;
 import net.ninjacat.omg.bytecode.AsmPatternCompiler;
 import net.ninjacat.omg.conditions.ConditionMethod;
 import net.ninjacat.omg.conditions.InCondition;
@@ -8,6 +8,8 @@ import net.ninjacat.omg.conditions.PropertyCondition;
 import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
+
+import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -57,8 +59,8 @@ public class CharCompilerTest {
 
     @Test
     public void shouldMatchInPattern() {
-        final PropertyCondition<java.util.List<Character>> condition =
-                new InCondition<>("charField", List.of((char) 42, (char) 84).asJava());
+        final PropertyCondition<Collection<Character>> condition =
+                new InCondition<>("charField", HashSet.of((char) 42, (char) 84).toJavaSet());
 
         final PropertyPattern<CharTest> pattern = AsmPatternCompiler.forClass(CharTest.class).build(condition);
 

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/DoubleCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/DoubleCompilerTest.java
@@ -9,6 +9,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -58,7 +60,7 @@ public class DoubleCompilerTest {
 
     @Test
     public void shouldMatchInPattern() {
-        final PropertyCondition<java.util.List<Double>> condition = new InCondition<>("doubleField", List.of(42.0, 84.0).asJava());
+        final PropertyCondition<Collection<Double>> condition = new InCondition<>("doubleField", List.of(42.0, 84.0).asJava());
 
         final PropertyPattern<DoubleTest> pattern = AsmPatternCompiler.forClass(DoubleTest.class).build(condition);
 

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/FloatCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/FloatCompilerTest.java
@@ -9,6 +9,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -58,7 +60,7 @@ public class FloatCompilerTest {
 
     @Test
     public void shouldMatchInPattern() {
-        final PropertyCondition<java.util.List<Float>> condition =
+        final PropertyCondition<Collection<Float>> condition =
                 new InCondition<>("floatField", List.of(42.0f, 84.0f).asJava());
 
         final PropertyPattern<FloatTest> pattern =

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/IntCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/IntCompilerTest.java
@@ -9,6 +9,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -57,7 +59,7 @@ public class IntCompilerTest {
 
     @Test
     public void shouldMatchInPattern() {
-        final PropertyCondition<java.util.List<Integer>> condition = new InCondition<>("intField", List.of(42, 84).asJava());
+        final PropertyCondition<Collection<Integer>> condition = new InCondition<>("intField", List.of(42, 84).asJava());
 
         final PropertyPattern<IntTest> pattern = AsmPatternCompiler.forClass(IntTest.class).build(condition);
 

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/LongCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/LongCompilerTest.java
@@ -9,6 +9,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -57,7 +59,7 @@ public class LongCompilerTest {
 
     @Test
     public void shouldMatchInPattern() {
-        final PropertyCondition<java.util.List<Long>> condition = new InCondition<>("longField", List.of(42L, 84L).asJava());
+        final PropertyCondition<Collection<Long>> condition = new InCondition<>("longField", List.of(42L, 84L).asJava());
 
         final PropertyPattern<LongTest> pattern = AsmPatternCompiler.forClass(LongTest.class).build(condition);
 

--- a/src/test/java/net/ninjacat/omg/bytecode/primitive/ShortCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/primitive/ShortCompilerTest.java
@@ -9,6 +9,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -57,7 +59,7 @@ public class ShortCompilerTest {
 
     @Test
     public void shouldMatchInPattern() {
-        final PropertyCondition<java.util.List<Short>> condition =
+        final PropertyCondition<Collection<Short>> condition =
                 new InCondition<>("shortField", List.of((short) 42, (short) 84).asJava());
 
         final PropertyPattern<ShortTest> pattern = AsmPatternCompiler.forClass(ShortTest.class).build(condition);

--- a/src/test/java/net/ninjacat/omg/bytecode/reference/BooleanCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/reference/BooleanCompilerTest.java
@@ -1,6 +1,6 @@
 package net.ninjacat.omg.bytecode.reference;
 
-import io.vavr.collection.List;
+import io.vavr.collection.HashSet;
 import net.ninjacat.omg.bytecode.AsmPatternCompiler;
 import net.ninjacat.omg.conditions.ConditionMethod;
 import net.ninjacat.omg.conditions.InCondition;
@@ -8,6 +8,8 @@ import net.ninjacat.omg.conditions.PropertyCondition;
 import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
+
+import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -50,8 +52,8 @@ public class BooleanCompilerTest {
 
     @Test(expected = CompilerException.class)
     public void shouldFailInPattern() {
-        final PropertyCondition<java.util.List<Boolean>> condition =
-                new InCondition<>("boolField", List.of(true, false).asJava());
+        final PropertyCondition<Collection<Boolean>> condition =
+                new InCondition<>("boolField", HashSet.of(true, false).toJavaSet());
 
         AsmPatternCompiler.forClass(BooleanTest.class).build(condition);
     }

--- a/src/test/java/net/ninjacat/omg/bytecode/reference/IntegerCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/bytecode/reference/IntegerCompilerTest.java
@@ -1,5 +1,6 @@
 package net.ninjacat.omg.bytecode.reference;
 
+import io.vavr.collection.HashSet;
 import io.vavr.collection.List;
 import net.ninjacat.omg.bytecode.AsmPatternCompiler;
 import net.ninjacat.omg.conditions.ConditionMethod;
@@ -58,6 +59,17 @@ public class IntegerCompilerTest {
     @Test
     public void shouldMatchInPattern() {
         final InCondition<Integer> condition = new InCondition<>("intField", List.of(42, 43).asJava());
+
+        final PropertyPattern<IntTest> pattern = AsmPatternCompiler.forClass(IntTest.class).build(condition);
+
+        assertThat(pattern.matches(new IntTest(42)), is(true));
+        assertThat(pattern.matches(new IntTest(21)), is(false));
+    }
+
+
+    @Test
+    public void shouldMatchInPatternWithSet() {
+        final InCondition<Integer> condition = new InCondition<>("intField", HashSet.of(42, 43).toJavaSet());
 
         final PropertyPattern<IntTest> pattern = AsmPatternCompiler.forClass(IntTest.class).build(condition);
 

--- a/src/test/java/net/ninjacat/omg/omql/QueryCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/omql/QueryCompilerTest.java
@@ -169,7 +169,7 @@ public class QueryCompilerTest {
         final Condition condition = queryCompiler.getCondition();
 
         final Condition expected = Conditions.matcher()
-                .property("age").in(io.vavr.collection.List.of(1, 2, 3).asJava())
+                .property("age").in(io.vavr.collection.HashSet.of(1, 2, 3).toJavaSet())
                 .build();
 
         assertThat(condition, is(expected));

--- a/src/test/java/net/ninjacat/omg/omql/TypedQueryCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/omql/TypedQueryCompilerTest.java
@@ -25,7 +25,7 @@ public class TypedQueryCompilerTest {
         final Condition condition = queryCompiler.getCondition();
 
         final Condition expected = Conditions.matcher()
-                .property("age").in(io.vavr.collection.List.of((short) 25, (short) 35, (short) 45).asJava())
+                .property("age").in(io.vavr.collection.HashSet.of((short) 25, (short) 35, (short) 45).toJavaSet())
                 .build();
 
         assertThat(condition, is(expected));
@@ -100,7 +100,7 @@ public class TypedQueryCompilerTest {
         final Condition condition = queryCompiler.getCondition();
 
         final Condition expected = Conditions.matcher()
-                .property("e").in(io.vavr.collection.List.of(E.E1, E.E2).asJava())
+                .property("e").in(io.vavr.collection.HashSet.of(E.E1, E.E2).toJavaSet())
                 .build();
 
         assertThat(condition, is(expected));
@@ -139,7 +139,7 @@ public class TypedQueryCompilerTest {
 
         final Condition expected = Conditions.matcher()
                 .property("sub").match(
-                        Conditions.matcher().property("number").in(io.vavr.collection.List.of(1, 2, 42).asJava()).build())
+                        Conditions.matcher().property("number").in(io.vavr.collection.HashSet.of(1, 2, 42).toJavaSet()).build())
                 .build();
 
         assertThat(condition, is(expected));

--- a/src/test/java/net/ninjacat/omg/reflect/BooleanCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/BooleanCompilerTest.java
@@ -8,6 +8,8 @@ import net.ninjacat.omg.errors.CompilerException;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -49,7 +51,7 @@ public class BooleanCompilerTest {
 
     @Test(expected = CompilerException.class)
     public void shouldFailInPattern() {
-        final PropertyCondition<java.util.List<Boolean>> condition =
+        final PropertyCondition<Collection<Boolean>> condition =
                 new InCondition<>("boolField", List.of(true, false).asJava());
 
         ReflectPatternCompiler.forClass(BooleanTest.class).build(condition);

--- a/src/test/java/net/ninjacat/omg/reflect/ByteCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/ByteCompilerTest.java
@@ -9,7 +9,7 @@ import net.ninjacat.omg.patterns.PatternCompiler;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -59,7 +59,7 @@ public class ByteCompilerTest {
 
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<Byte>> condition = new InCondition<>(
+        final PropertyCondition<Collection<Byte>> condition = new InCondition<>(
                 "byteField",
                 io.vavr.collection.List.of((byte) 21, (byte) 42, (byte) 11).asJava());
 

--- a/src/test/java/net/ninjacat/omg/reflect/CharCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/CharCompilerTest.java
@@ -8,7 +8,7 @@ import net.ninjacat.omg.patterns.PatternCompiler;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -60,7 +60,7 @@ public class CharCompilerTest {
 
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<Character>> condition = new InCondition<>(
+        final PropertyCondition<Collection<Character>> condition = new InCondition<>(
                 "charField",
                 io.vavr.collection.List.of((char) 21, (char) 42, (char) 11).asJava());
 

--- a/src/test/java/net/ninjacat/omg/reflect/DoubleCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/DoubleCompilerTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.junit.experimental.theories.Theories;
 import org.junit.runner.RunWith;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -64,7 +64,7 @@ public class DoubleCompilerTest {
 
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<Double>> condition = new InCondition<>(
+        final PropertyCondition<Collection<Double>> condition = new InCondition<>(
                 "doubleField",
                 io.vavr.collection.List.of(21.0, 42.0, 11.5).asJava());
 

--- a/src/test/java/net/ninjacat/omg/reflect/EnumCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/EnumCompilerTest.java
@@ -8,7 +8,7 @@ import net.ninjacat.omg.patterns.PatternCompiler;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -46,7 +46,7 @@ public class EnumCompilerTest {
 
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<EnumValues>> condition = new InCondition<>(
+        final PropertyCondition<Collection<EnumValues>> condition = new InCondition<>(
                 "enumField",
                 io.vavr.collection.List.of(EnumValues.E1, EnumValues.E2, EnumValues.E4).asJava());
 

--- a/src/test/java/net/ninjacat/omg/reflect/FloatCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/FloatCompilerTest.java
@@ -9,7 +9,7 @@ import net.ninjacat.omg.patterns.PatternCompiler;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -62,7 +62,7 @@ public class FloatCompilerTest {
     // TODO: Convert to Theory to test both reflection and compiled pattern
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<Float>> condition = new InCondition<>(
+        final PropertyCondition<Collection<Float>> condition = new InCondition<>(
                 "floatField",
                 io.vavr.collection.List.of(21.0f, 42.0f, 11.5f).asJava());
 

--- a/src/test/java/net/ninjacat/omg/reflect/IntCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/IntCompilerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.experimental.theories.Theories;
 import org.junit.runner.RunWith;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +65,7 @@ public class IntCompilerTest {
 
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<Integer>> condition = new InCondition<>(
+        final PropertyCondition<Collection<Integer>> condition = new InCondition<>(
                 "intField",
                 io.vavr.collection.List.of(21, 42, 11).asJava());
 

--- a/src/test/java/net/ninjacat/omg/reflect/LongCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/LongCompilerTest.java
@@ -9,7 +9,7 @@ import net.ninjacat.omg.patterns.PatternCompiler;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -40,7 +40,7 @@ public class LongCompilerTest {
     // TODO: Convert to Theory to test both reflection and compiled pattern
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<Long>> condition = new InCondition<>(
+        final PropertyCondition<Collection<Long>> condition = new InCondition<>(
                 "longField",
                 io.vavr.collection.List.of(21L, 42L, 11L).asJava());
 

--- a/src/test/java/net/ninjacat/omg/reflect/ShortCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/ShortCompilerTest.java
@@ -1,5 +1,6 @@
 package net.ninjacat.omg.reflect;
 
+import io.vavr.collection.HashSet;
 import net.ninjacat.omg.conditions.ConditionMethod;
 import net.ninjacat.omg.conditions.InCondition;
 import net.ninjacat.omg.conditions.PropertyCondition;
@@ -9,7 +10,7 @@ import net.ninjacat.omg.patterns.PatternCompiler;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -61,9 +62,9 @@ public class ShortCompilerTest {
     // TODO: Convert to Theory to test both reflection and compiled pattern
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<Short>> condition = new InCondition<>(
+        final PropertyCondition<Collection<Short>> condition = new InCondition<>(
                 "shortField",
-                io.vavr.collection.List.of((short) 21, (short) 42, (short) 11).asJava());
+                HashSet.of((short) 21, (short) 42, (short) 11).toJavaSet());
 
 
         final PropertyPattern<ShortTest> pattern = ReflectPatternCompiler.forClass(ShortTest.class).build(condition);

--- a/src/test/java/net/ninjacat/omg/reflect/StringCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/reflect/StringCompilerTest.java
@@ -9,7 +9,7 @@ import net.ninjacat.omg.patterns.PatternCompiler;
 import net.ninjacat.omg.patterns.PropertyPattern;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collection;
 
 import static net.ninjacat.omg.patterns.CompilingStrategy.SAFE;
 import static org.hamcrest.Matchers.is;
@@ -56,7 +56,7 @@ public class StringCompilerTest {
 
     @Test
     public void shouldMatchSimpleInPattern() {
-        final PropertyCondition<List<String>> condition = new InCondition<>(
+        final PropertyCondition<Collection<String>> condition = new InCondition<>(
                 "stringField",
                 io.vavr.collection.List.of("Waldo", "Wally", "von Ludensdorf").asJava());
 


### PR DESCRIPTION
This fixes #38.

OMQL now compiles `IN (items)` into `Set` instead of `List`. This should speed up check, but requires items to be hashable (which is not a problem, given that only enums, numbers and strings are supported).