### PR TITLE
Add 'match' clause support in OMQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ hs_err_pid*
 ### Gradle template
 .gradle
 /build/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ jacocoTestReport {
 }
 
 group 'net.ninjacat'
-version '0.2.0-SNAPSHOT'
+version '0.1.6'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/docs/omql.md
+++ b/docs/omql.md
@@ -10,14 +10,14 @@ own quirks.
     SELECT * FROM com.example.MyObject WHERE name ~= "John.*" AND friendsCount > 3 
 ```
 
-Only supported type of queries is `SELECT` and queries must follow followin pattern:
+Only supported type of SQL-like queries is `SELECT` and queries must follow following pattern:
 
 SELECT * FROM `<class-name>` WHERE `<list-of-conditions>`
 
- In current implementation only `*` can appear in SELECT clause.
+In current implementation only `*` can appear in SELECT clause.
  
- `<class-name>` is either a fully-qualified Java class name or a short name of registered class (see below).
- 
+`<class-name>` is either a fully-qualified Java class name or a short name of registered class (see below).
+
  `<list-of-conditions>` is a list (tree, to be precise) of conditions consisting of field comparison combined with logical 
  operators. List of supported operators depends on field type.
  
@@ -28,6 +28,17 @@ SELECT * FROM `<class-name>` WHERE `<list-of-conditions>`
  | String              | `=`, `!=`, `~=`, `IN (list)`           |
  | Enum                | `=`, `!=`, `~=`, `IN (list)`           |
  | Object              | `=`, `!=`, `~=`, `IN (subquery)`       |
+ 
+
+`SELECT * FROM` syntax is familiar from SQL and matches nicely to stream filtering paradigm, but it is a bit misleading 
+when predicate is created for a purpose of matching single object.
+
+`MATCH` clause is added as syntactic sugar replacement for `SELECT * FROM`, it clearly declares intent of producing matching predicate,
+not a filtering query:
+
+```
+    MATCH com.example.MyObject WHERE name ~= "John.*" AND friendsCount > 3 
+```
  
   
  ## Integrating queries into your code

--- a/src/main/antlr/net/ninjacat/omg/omql/parser/Omql.g4
+++ b/src/main/antlr/net/ninjacat/omg/omql/parser/Omql.g4
@@ -42,9 +42,18 @@ where
  : K_WHERE expr
  ;
 
-select
+select_clause
  : K_SELECT '*'
-   K_FROM source_name
+   K_FROM
+ ;
+
+match_clause
+ : K_MATCH
+ ;
+
+select
+ : (select_clause | match_clause)
+   source_name
    where?
  ;
 
@@ -89,6 +98,7 @@ K_NULL: N U L L;
 K_OR: O R;
 K_REGEX: R E G E X;
 K_SELECT: S E L E C T;
+K_MATCH: M A T C H;
 K_WHERE : W H E R E;
 K_TRUE: T R U E;
 K_FALSE: F A L S E;

--- a/src/test/java/net/ninjacat/omg/omql/QueryCompilerTest.java
+++ b/src/test/java/net/ninjacat/omg/omql/QueryCompilerTest.java
@@ -33,6 +33,18 @@ public class QueryCompilerTest {
     }
 
     @Test
+    public void shouldConvertSimpleMatchQuery() {
+        final QueryCompiler queryCompiler = QueryCompiler.of("match Person where age > 25", SOURCES);
+        final Condition condition = queryCompiler.getCondition();
+
+        final Condition expected = Conditions.matcher()
+                .property("age").gt(25)
+                .build();
+
+        assertThat(condition, is(expected));
+    }
+
+    @Test
     public void shouldConvertGteQuery() {
         final QueryCompiler queryCompiler = QueryCompiler.of("select * from JetPilot where age >= 25", SOURCES);
         final Condition condition = queryCompiler.getCondition();


### PR DESCRIPTION
Construct `SELECT * FROM <Class> WHERE ...` while familiar to SQL users
does not describe nicely creating matcher, not a stream filter.

`MATCH <Class> WHERE ...` while producing the same results, clearly shows
intent to create matcher (aka Predicate) not filter.

There is no changes in behaviour, this is pure syntactic sugar, even OMQL AST is
almost unchanged.